### PR TITLE
Speed up pymfeindex for large inputs, and keep tighter bounds on memory usage.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,5 @@
 Copyright (c) 2013 Wubin Qu
+Copyright (c) 2015 Genome Research Limited
 
 MIT License
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,26 @@ Or install it yourself as:
 
 ## Usage
 
-`mfeindex fasta_file [kvalue]`
+`mfeindex fasta_file [-m mem_limit] [kvalue]`
+
+mem_limit is the amount of memory to use during the indexing stage, in
+megabytes.  The default is 200; for large data sets (e.g. Human) this
+should be increased (4000 seems to work fairly well, but bigger is better
+if you have the memory available).  The -m option only controls memory
+consumption for part of the indexing process, so the total used will be
+somewhat higher than the given value.
+
+Any data that doesn't fit in memory while sorting will be written to
+temporary files and merged back in later.  The exact space used depends
+on the input data, but should be around 8 bytes per base of the input
+sequences.  The files will normally go into the default location for
+temporary data on your platform (e.g. /tmp on UNIX-like systems).  The TMPDIR
+environment variable can be used to change this if you want to put them
+somewhere else.
+
+As an example, indexing a 3 Gbyte fasta file with -m 4000 used 6.6 Gbytes of
+memory and 20 Gbytes of temporary storage.  The output index file was 50 Gbytes
+long.
 
 ## Contributing
 

--- a/bin/mfeindex
+++ b/bin/mfeindex
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require 'getoptlong'
 require 'qu/mfeindex'
 
 def split_db(big_db)
@@ -53,7 +54,7 @@ def split_db(big_db)
 end
 
 
-def index_db(fasta_file, kvalue)
+def index_db(fasta_file, kvalue, mem_limit)
   if Qu::Mfeindex::db_indexed?(fasta_file)
     $stdout.print "#{fasta_file} has already been indexed, do you want to reindex? [y/N]:"
     choice = $stdin.gets.chomp.downcase
@@ -67,9 +68,9 @@ def index_db(fasta_file, kvalue)
   end
 
   if choice == 'y'
-    Qu::Mfeindex::MFEprimerIndex(fasta_file, kvalue, reindex=true)
+    Qu::Mfeindex::MFEprimerIndex(fasta_file, kvalue, mem_limit, reindex=true)
   else
-    Qu::Mfeindex::MFEprimerIndex(fasta_file, kvalue, reindex=false)
+    Qu::Mfeindex::MFEprimerIndex(fasta_file, kvalue, mem_limit, reindex=false)
   end
 end
 
@@ -78,15 +79,25 @@ usage = "Index database for MFEprimer-2.0
 
 Usage:
 
-  #{File.basename($0)} fasta_file [kvalue]
+  #{File.basename($0)} [-m sort_mem_limit] fasta_file [kvalue]
 
   
   Options:
   
+  -m    : Memory limit for sorting step, Megabytes.  Default is 200 [Integer].
   kvalue: Default is 9 [Integer].
 
 Contact: Wubin Qu <quwubin@gmail.com>
 "
+
+opts = GetoptLong.new(
+  [ "--mem_limit", "-m", GetoptLong::REQUIRED_ARGUMENT ]
+)
+
+mem_limit = 200
+opts.each do |opt, arg|
+  mem_limit = arg.to_i if (opt == "--mem_limit")
+end
 
 case ARGV.size
 when 2
@@ -121,8 +132,8 @@ end
 if choice == 'y'
   small_file_list = split_db(fasta_file)
   small_file_list.each do |small_file|
-    index_db(small_file, kvalue)
+    index_db(small_file, kvalue, mem_limit)
   end
 else
-  index_db(fasta_file, kvalue)
+  index_db(fasta_file, kvalue, mem_limit)
 end

--- a/bin/mfeindex
+++ b/bin/mfeindex
@@ -90,13 +90,16 @@ Usage:
 Contact: Wubin Qu <quwubin@gmail.com>
 "
 
-opts = GetoptLong.new(
-  [ "--mem_limit", "-m", GetoptLong::REQUIRED_ARGUMENT ]
-)
+opts = GetoptLong.new(["--mem_limit", "-m", GetoptLong::REQUIRED_ARGUMENT],
+                      ["--split", GetoptLong::NO_ARGUMENT ],
+                      ["--nosplit", GetoptLong::NO_ARGUMENT ])
 
-mem_limit = 200
+mem_limit = 200     # Memory limit for pymfeindex
+choice = nil        # Should file be split?
 opts.each do |opt, arg|
   mem_limit = arg.to_i if (opt == "--mem_limit")
+  choice = 'y' if (opt == "--split")
+  choice = 'n' if (opt == "--nosplit")
 end
 
 case ARGV.size
@@ -117,16 +120,20 @@ unless File.exists?(fasta_file)
   exit
 end
 
-if File.size(fasta_file) > Qu::Mfeindex::BIG_DB_SPLIT_CUTOFF
-  $stdout.print "#{fasta_file} is too large, do you want to split it first? [Y/n]:"
-  choice = $stdin.gets.chomp.downcase
-  choice = 'y' if choice.empty?
-  while !['y', 'n'].include?(choice)
-    $stdout.print "The choice should be 'y' or 'n':"
+if choice.nil?
+  if File.size(fasta_file) > Qu::Mfeindex::BIG_DB_SPLIT_CUTOFF
+    $stdout.print "#{fasta_file} is too large, do you want to split it first? [Y/n]:"
     choice = $stdin.gets.chomp.downcase
+    choice = 'y' if choice.empty?
+    while !['y', 'n'].include?(choice)
+      $stdout.print "The choice should be 'y' or 'n':"
+      choice = $stdin.gets.chomp.downcase
+    end
+  else
+    choice = 'n'
   end
-else
-  choice = 'n'
+elsif File.size(fasta_file) <= Qu::Mfeindex::BIG_DB_SPLIT_CUTOFF
+  choice = 'n' # No need to split if file is small
 end
 
 if choice == 'y'

--- a/lib/qu/mfeindex.rb
+++ b/lib/qu/mfeindex.rb
@@ -59,7 +59,7 @@ module Qu
       end
     end
 
-    def MFEprimerIndex(fasta_file, k = 9, reindex = false)
+    def MFEprimerIndex(fasta_file, k = 9, mem_limit = 200, reindex = false)
       return if !reindex and db_indexed?(fasta_file)
 
       unless File.exists?(fasta_file)
@@ -85,7 +85,7 @@ module Qu
 
       cmd = File.join(__dir__, 'pymfeindex')
       $stderr.puts "Begin index database: #{fasta_file}"
-      `#{cmd} -f #{uni_fasta} -k #{k} -o #{fasta_file + DB_SQLITE3}`
+      `#{cmd} -f #{uni_fasta} -m #{mem_limit} -k #{k} -o #{fasta_file + DB_SQLITE3}`
       begin
         File.delete(uni_fasta)
       rescue

--- a/lib/qu/pymfeindex
+++ b/lib/qu/pymfeindex
@@ -302,6 +302,43 @@ def DNA2int_2(seq):
 
     return plus_mer, minus_mer
 
+def seq_iter(seq, k):
+    '''Iterate through the sequence returning (pos, plus_mer, minus_mer)
+    tuples.'''
+    mask = (4 ** k) - 1
+    plus_mer  = -1
+    minus_mer = -1
+    pos = 0
+    while pos < len(seq) - k + 1:
+        if plus_mer < 0:
+            # Calculate over full kmer
+            try:
+                plus_mer, minus_mer = DNA2int_2(seq[pos:pos + k])
+                yield pos, plus_mer, minus_mer
+                pos += 1
+            except:
+                # Unrecognised base.  Find the offending character and
+                # skip past it
+                i = pos + k - 1
+                while i > pos and D2n_dic.has_key(seq[i]):
+                    i -= 1
+                pos = i + 1
+                plus_mer = -1
+        else:
+            # Update
+            c = seq[pos + k - 1]
+            if D2n_dic.has_key(c):
+                v = D2n_dic[c]
+                plus_mer = (plus_mer << 2) & mask | v
+                minus_mer = (minus_mer >> 2) | ((3 - v) << 2 * (k - 1))
+                yield pos, plus_mer, minus_mer
+                pos += 1
+            else:
+                # Last base unrecognised.  Skip entire kmer and restart
+                pos += k
+                plus_mer = -1
+                
+
 def DNA2int(seq):
     '''convert a sub-sequence/seq to a non-negative integer'''
     plus_mer = 0
@@ -367,14 +404,7 @@ def index(filename, k, dbname, memlimit):
         record_names.append(record_id)
         record_num = len(record_names) - 1
 
-        for i in xrange(len(fasta_seq)-k + 1):
-            kmer = fasta_seq[i:(i+k)]
-
-            try:
-                plus_mer_id, minus_mer_id = DNA2int_2(kmer)
-            except:
-                # Skip the unrecognized base, such as 'N'
-                continue
+        for i, plus_mer_id, minus_mer_id in seq_iter(fasta_seq, k):
 
             plus_bin = plus_mer_id >> kshift & 255
             minus_bin = minus_mer_id >> kshift & 255

--- a/lib/qu/pymfeindex
+++ b/lib/qu/pymfeindex
@@ -19,6 +19,10 @@ D2n_dic = dict(A=0, T=3, C=2, G=1, a=0, t=3, c=2, g=1)
 n2D_dic = {0:'A', 3:'T', 2:'C', 1:'G', 0:'a', 3:'t', 2:'c', 1:'g'}
 
 class Chunk:
+    '''Class to store information about a sorted segment of the data in
+    a temporary file.  It records which file the data is stored in, and
+    there the segment starts in that file.  It also provides an iterator
+    allowing the stored data to be read back again.'''
     def __init__(self, item_len, f, pos):
         self.file = f
         self.file_pos = pos
@@ -32,7 +36,7 @@ class Chunk:
 
         item_len = self.item_len
         max_seg_len = 1000
-        for seg_start in range(0, self.count, max_seg_len):
+        for seg_start in xrange(0, self.count, max_seg_len):
             self.file.seek(self.file_pos + seg_start * item_len, 0)
             if seg_start + max_seg_len <= self.count:
                 seg_len = max_seg_len
@@ -40,21 +44,45 @@ class Chunk:
                 seg_len = self.count - seg_start
             seg = self.file.read(seg_len * item_len)
             
-            for i in range(seg_len):
+            for i in xrange(seg_len):
                 yield seg[i * item_len:(i + 1) * item_len]
         
+class StrIter:
+    '''Class to iterate through items packed into a bytearray, or a
+    list of bytearrays.  Used to iterate through the last segment of the
+    data without having to write it to a temporary file.'''
+    def __init__(self, item_len, s):
+        if isinstance(s, list):
+            self.strs = s
+        else:
+            self.strs = [s]
+        self.item_len = item_len
+
+    def __iter__(self):
+        for s in self.strs:
+            for pos in xrange(0, len(s), self.item_len):
+                yield str(s[pos:pos + self.item_len])
 
 class MergeSorter:
     '''class to handle spilling excess data to temporary files and
     merging it when reading it back'''
 
-    '''limit individual file size to 2G'''
+    # limit individual file size to 2G
     max_file_size = 2000000000
     tmp_files = []
     chunks = []
 
-    def __init__(self, l):
+    def __init__(self, l, k):
         self.len = l
+        # Work out which bytes to radix sort on.  As the data gets stored
+        # in position order, we only actually need to sort on mer_id
+        # and direction (in the top bit of the record_id) as long
+        # as the sort is stable.  We also don't need to bother with
+        # the top 8 bits of mer_id as we bin on those bits already
+        # so they'll be identical for everything in the same bin.
+        self.sort_start_byte = l - calcsize('I') * 2 - int((k + 3 - 4) / 4)
+        self.sort_end_byte = l - calcsize('I') * 2 + 1
+        self.max_items = int(self.max_file_size / l)
 
     def new_tmp_file(self):
         f = TemporaryFile()
@@ -67,36 +95,85 @@ class MergeSorter:
         else:
             return self.new_tmp_file()
 
-    def store(self, data):
+    def radix_sort_byte(self, item, byte):
+        '''Stable radix sort on byte "byte" of entries in the bytearray "item"'''
+        # Count number of items in each bin
+        counts = [0 for x in xrange(256)]
+        for p in xrange(byte, len(item), self.len):
+            counts[item[p]] += 1
+
+        # Work out where the items for each bin will go in the output array
+        pos = [0]
+        used_bins = 0
+        for n, c in enumerate(counts):
+            pos.append(pos[n] + c * self.len)
+            used_bins += 1 if c > 0 else 0
+
+        # Short-cut if there is only 1 bin as the input is already sorted
+        if used_bins < 2:
+            return item
+
+        # Re-order into the new bytearray and return it.
+        out = bytearray(item)
+        for p in xrange(0, len(item), self.len):
+            b = item[p + byte]
+            out[pos[b]:pos[b] + self.len] = item[p:p + self.len]
+            pos[b] += self.len
+
+        return out
+
+    def store(self, items):
+        '''Sort and write items to a temporary file, and add to the list of
+        segments to merge.'''
         f = self.get_curr_file_num()
         pos = f.tell()
 
         chunk = Chunk(self.len, f, pos)
 
-        data.sort()
+        last_byte = self.len - 7
 
-        for item in data:
-            f.write(item)
-            chunk.count += 1
-            pos += self.len
-            if pos >= self.max_file_size:
-                self.chunks.append(chunk)
-                f = self.new_tmp_file()
-                pos = 0
-                chunk = Chunk(self.len, f, pos)
+        for b in xrange(256):
+            # LSD radix sort items[b]
+            for byte in reversed(xrange(self.sort_start_byte, self.sort_end_byte)):
+                items[b] = self.radix_sort_byte(items[b], byte)
 
-        if pos > 0:
+            # Write sorted data to the spill file
+            csz = 8192
+            num = int(len(items[b]) / self.len)
+            i = 0
+            while i < num:
+                sz = csz if pos + csz * self.len < self.max_file_size \
+                     else int((self.max_file_size - pos) / self.len) + 1
+                end = i + sz if i + sz < num else num
+                f.write(items[b][i * self.len:end * self.len])
+                chunk.count += end - i
+                pos += (end - i) * self.len
+                i = end
+                if pos >= self.max_file_size:
+                    # Start a new file
+                    self.chunks.append(chunk)
+                    f = self.new_tmp_file()
+                    pos = 0
+                    chunk = Chunk(self.len, f, pos)
+                
+        if chunk.count > 0:
             self.chunks.append(chunk)
 
-    def store_last(self, data):
-        data.sort()
-        self.chunks.append(data)
+    def store_last(self, items):
+        '''Sort last items and add them to the list of segments to merge.
+        In this case there is no need to save them.'''
+        for b in xrange(256):
+            # LSD radix sort items[b]
+            for byte in reversed(xrange(self.sort_start_byte, self.sort_end_byte)):
+                items[b] = self.radix_sort_byte(items[b], byte)
+        self.chunks.append(StrIter(self.len, items))
 
     def __iter__(self):
         '''Use the heapq merge function to get an iterator that merges
         all the chunks together'''
         return merge(*self.chunks)
-    
+
+
 def print_usage():
     print '''
 %s: Index DB for MFEprimer-2.0
@@ -115,7 +192,7 @@ def optget():
     parser.add_option("-f", "--file", dest = "filename", help = "DNA file in fasta to be indexed")
     parser.add_option("-k", "--k", dest = "k", type='int', help = "K mer , default is 9", default = 9)
     parser.add_option("-o", "--out", dest = "out", help = "Index db file name")
-    parser.add_option("-c", "--chunk", dest = "chunk", help = "Number of kmers to sort in memory", default=1000000)
+    parser.add_option("-m", "--memlimit", dest = "memlimit", help = "Memory limit for sorting (megabytes)", default=200)
 
     (options, args) = parser.parse_args()
 
@@ -126,8 +203,8 @@ def optget():
     if not options.out:
         options.out = options.filename + '.sqlite3.db'
 
-    if options.chunk < 10000:
-        options.chunk = 10000
+    if options.memlimit < 100:
+        options.memlimit = 100
 
     return options
 
@@ -245,7 +322,7 @@ def store_to_db(conn, mer_id, next_mer_id, collation, record_names):
                      "values (?, ?, ?)",
                      ((x, '', '') for x in range(mer_id + 1, next_mer_id)))
 
-def index(filename, k, dbname, max_count):
+def index(filename, k, dbname, memlimit):
     ''''''
     start = time()
 
@@ -275,10 +352,13 @@ def index(filename, k, dbname, max_count):
         fmt = '>III'
 
     fmt_len = calcsize(fmt)
-    sorter = MergeSorter(fmt_len)
+    max_count = memlimit * 2**20 // fmt_len
+    sorter = MergeSorter(fmt_len, k)
+
+    kshift = 2 * k - 8 if k > 4 else 0
 
     # Accumulator for packed data items
-    items = []
+    items = [bytearray("") for x in xrange(256)]
 
     # Get data and sort
     for record_id, record_desc, fasta_seq in parse_fasta_format(open(filename)):
@@ -296,22 +376,30 @@ def index(filename, k, dbname, max_count):
                 # Skip the unrecognized base, such as 'N'
                 continue
 
-            items.append(pack(fmt, plus_mer_id, record_num, i + k - 1))
-            items.append(pack(fmt, minus_mer_id, record_num | 0x80000000, i))
+            plus_bin = plus_mer_id >> kshift & 255
+            minus_bin = minus_mer_id >> kshift & 255
+            items[plus_bin].extend(pack(fmt, plus_mer_id, record_num, i + k - 1))
+            items[minus_bin].extend(pack(fmt, minus_mer_id, record_num | 0x80000000, i))
             count += 2
 
             if count >= max_count:
+                # print "@ %s : flushing out data" % str(datetime.timedelta(seconds=(time() - start)))
                 sorter.store(items)
-                items = []
+                # print "@ %s : flushed out data" % str(datetime.timedelta(seconds=(time() - start)))
+                # items = []
+                items = [bytearray("") for x in xrange(256)]
                 count = 0
                 
     # Don't forget the last bit
+    # print "@ %s : flushing out last data" % str(datetime.timedelta(seconds=(time() - start)))
     sorter.store_last(items)
+    # print "@ %s : flushed out last data" % str(datetime.timedelta(seconds=(time() - start)))
 
     # Merge it all together
     last_kmer = -1
     last_collation = { '+' : [], '-' : [] }
-    
+
+    # print "@ %s : starting merge phase" % str(datetime.timedelta(seconds=(time() - start)))
     for item in sorter:
         mer_id, record_num, pos = unpack(fmt, item)
         if record_num < 0x80000000:
@@ -339,7 +427,7 @@ def index(filename, k, dbname, max_count):
 def main():
     '''main'''
     options = optget()
-    index(options.filename, options.k, options.out, options.chunk)
+    index(options.filename, options.k, options.out, options.memlimit)
 
 if __name__ == "__main__":
     main()

--- a/lib/qu/pymfeindex
+++ b/lib/qu/pymfeindex
@@ -213,7 +213,7 @@ def optget():
     parser.add_option("-f", "--file", dest = "filename", help = "DNA file in fasta to be indexed")
     parser.add_option("-k", "--k", dest = "k", type='int', help = "K mer , default is 9", default = 9)
     parser.add_option("-o", "--out", dest = "out", help = "Index db file name")
-    parser.add_option("-m", "--memlimit", dest = "memlimit", help = "Memory limit for sorting (megabytes)", default=200)
+    parser.add_option("-m", "--memlimit", dest = "memlimit", help = "Memory limit for sorting (megabytes)", type=int, default=200)
 
     (options, args) = parser.parse_args()
 
@@ -229,6 +229,22 @@ def optget():
 
     return options
 
+def fasta_sequence_iterator(fh):
+    line_start = True
+    while True:
+        ch = fh.read(1)
+        if not ch:
+            return
+        if line_start and ch == '>':
+            return
+        if ch == "\n":
+            line_start = True
+            continue
+        line_start = False
+        if not ch.isspace():
+            yield ch
+        
+
 def parse_fasta_format(fh):
     '''
     A Fasta-format Parser return Iterator
@@ -241,34 +257,17 @@ def parse_fasta_format(fh):
         line = line.strip()
 
         if line.startswith('>'):
+            line = line.lstrip('>')
             break
 
     while True:
-        if not line.startswith('>'):
-            raise ValueError("Records in Fasta files should start with '>' character")
-
-        id, sep, desc = line[1:].partition(' ')
-
-        seq_lines = []
-        line = fh.readline()
-        while True:
-            if not line: break
-
-            line = line.strip()
-
-            if line.startswith('>'):
-                break
-
-            if not line:
-                line = fh.readline()
-                continue
-
-            seq_lines.append(line.replace(' ', '').replace("\r", ''))
-            line = fh.readline()
-
-        yield (id, desc, ''.join(seq_lines))
-
         if not line: return
+        id, sep, desc = line.partition(' ')
+
+        yield(id, desc, fasta_sequence_iterator(fh))
+
+        line = fh.readline()
+        line = line.strip()
 
     assert False, 'Should not reach this line'
 
@@ -330,24 +329,33 @@ def seq_iter(seq, k):
     plus_mer  = -1
     minus_mer = -1
     pos = 0
-    while pos < len(seq) - k + 1:
+    kmer = ''
+    while True:
         if plus_mer < 0:
             # Calculate over full kmer
+            kmer = kmer + ''.join(seq.next() for i in xrange(k - len(kmer)))
+            if len(kmer) < k:
+                return
             try:
-                plus_mer, minus_mer = DNA2int_2(seq[pos:pos + k])
+                plus_mer, minus_mer = DNA2int_2(kmer)
                 yield pos, plus_mer, minus_mer
                 pos += 1
             except:
                 # Unrecognised base.  Find the offending character and
                 # skip past it
-                i = pos + k - 1
-                while i > pos and D2n_dic.has_key(seq[i]):
-                    i -= 1
-                pos = i + 1
+                i = k - 1
+                try:
+                    while i > 0 and D2n_dic.has_key(kmer[i]):
+                        i -= 1
+                except:
+                    print "%d %s %d" % (i, kmer, pos)
+                    raise IndexError("string index out of range")
+                kmer = kmer[i + 1:]
+                pos += i + 1
                 plus_mer = -1
         else:
             # Update
-            c = seq[pos + k - 1]
+            c = seq.next()
             if D2n_dic.has_key(c):
                 v = D2n_dic[c]
                 plus_mer = (plus_mer << 2) & mask | v
@@ -358,6 +366,7 @@ def seq_iter(seq, k):
                 # Last base unrecognised.  Skip entire kmer and restart
                 pos += k
                 plus_mer = -1
+                kmer = ''
                 
 
 def DNA2int(seq):

--- a/lib/qu/pymfeindex
+++ b/lib/qu/pymfeindex
@@ -13,6 +13,7 @@ import subprocess
 import re
 from struct import *
 from heapq import *
+from zlib import *
 from tempfile import TemporaryFile
 
 D2n_dic = dict(A=0, T=3, C=2, G=1, a=0, t=3, c=2, g=1)
@@ -28,6 +29,7 @@ class Chunk:
         self.file_pos = pos
         self.item_len = item_len
         self.count = 0
+        self.compressed_len = 0
 
     def __iter__(self):
         '''generator function to iterate through the stored data'''
@@ -35,18 +37,26 @@ class Chunk:
             return
 
         item_len = self.item_len
-        max_seg_len = 1000
-        for seg_start in xrange(0, self.count, max_seg_len):
-            self.file.seek(self.file_pos + seg_start * item_len, 0)
-            if seg_start + max_seg_len <= self.count:
-                seg_len = max_seg_len
-            else:
-                seg_len = self.count - seg_start
-            seg = self.file.read(seg_len * item_len)
-            
-            for i in xrange(seg_len):
-                yield seg[i * item_len:(i + 1) * item_len]
-        
+        max_seg_len = 8192
+        decomp = decompressobj()
+        carry_over = ""
+        for seg_start in xrange(0, self.compressed_len, max_seg_len):
+            self.file.seek(self.file_pos + seg_start, 0)
+            seg_len = max_seg_len \
+                      if seg_start + max_seg_len < self.compressed_len \
+                      else self.compressed_len - seg_start
+            seg = self.file.read(seg_len)
+            data = carry_over + decomp.decompress(decomp.unconsumed_tail + seg)
+            i = 0
+            while i + item_len <= len(data):
+                yield data[i:i + item_len]
+                i += item_len
+            carry_over = data[i:]
+
+        data = carry_over + decomp.flush()
+        for i in xrange(0, len(data), item_len):
+            yield data[i:i + item_len]
+                
 class StrIter:
     '''Class to iterate through items packed into a bytearray, or a
     list of bytearrays.  Used to iterate through the last segment of the
@@ -129,8 +139,7 @@ class MergeSorter:
         pos = f.tell()
 
         chunk = Chunk(self.len, f, pos)
-
-        last_byte = self.len - 7
+        comp = compressobj(1)
 
         for b in xrange(256):
             # LSD radix sort items[b]
@@ -138,26 +147,38 @@ class MergeSorter:
                 items[b] = self.radix_sort_byte(items[b], byte)
 
             # Write sorted data to the spill file
-            csz = 8192
+            sz = 8192
             num = int(len(items[b]) / self.len)
             i = 0
             while i < num:
-                sz = csz if pos + csz * self.len < self.max_file_size \
-                     else int((self.max_file_size - pos) / self.len) + 1
                 end = i + sz if i + sz < num else num
-                f.write(items[b][i * self.len:end * self.len])
+
+                shrunk = comp.compress(str(items[b][i * self.len:end * self.len]))
+                f.write(shrunk)
                 chunk.count += end - i
-                pos += (end - i) * self.len
+                pos += len(shrunk)
+                chunk.compressed_len += len(shrunk)
                 i = end
                 if pos >= self.max_file_size:
+                    # Finish compressed stream
+                    remain = comp.flush()
+                    f.write(remain)
+                    chunk.compressed_len += len(remain)
+                    # print "Wrote tmp file count = %d compressed size = %d" % (chunk.count, chunk.compressed_len)
                     # Start a new file
                     self.chunks.append(chunk)
                     f = self.new_tmp_file()
+                    comp = compressobj(1)
                     pos = 0
                     chunk = Chunk(self.len, f, pos)
                 
         if chunk.count > 0:
+            # Finish compressed stream
+            remain = comp.flush()
+            f.write(remain)
+            chunk.compressed_len += len(remain)
             self.chunks.append(chunk)
+            # print "Wrote tmp file count = %d compressed size = %d" % (chunk.count, chunk.compressed_len)
 
     def store_last(self, items):
         '''Sort last items and add them to the list of segments to merge.

--- a/lib/qu/pymfeindex
+++ b/lib/qu/pymfeindex
@@ -11,11 +11,92 @@ import sqlite3
 import platform
 import subprocess
 import re
-
+from struct import *
+from heapq import *
+from tempfile import TemporaryFile
 
 D2n_dic = dict(A=0, T=3, C=2, G=1, a=0, t=3, c=2, g=1)
 n2D_dic = {0:'A', 3:'T', 2:'C', 1:'G', 0:'a', 3:'t', 2:'c', 1:'g'}
 
+class Chunk:
+    def __init__(self, item_len, f, pos):
+        self.file = f
+        self.file_pos = pos
+        self.item_len = item_len
+        self.count = 0
+
+    def __iter__(self):
+        '''generator function to iterate through the stored data'''
+        if self.count == 0:
+            return
+
+        item_len = self.item_len
+        max_seg_len = 1000
+        for seg_start in range(0, self.count, max_seg_len):
+            self.file.seek(self.file_pos + seg_start * item_len, 0)
+            if seg_start + max_seg_len <= self.count:
+                seg_len = max_seg_len
+            else:
+                seg_len = self.count - seg_start
+            seg = self.file.read(seg_len * item_len)
+            
+            for i in range(seg_len):
+                yield seg[i * item_len:(i + 1) * item_len]
+        
+
+class MergeSorter:
+    '''class to handle spilling excess data to temporary files and
+    merging it when reading it back'''
+
+    '''limit individual file size to 2G'''
+    max_file_size = 2000000000
+    tmp_files = []
+    chunks = []
+
+    def __init__(self, l):
+        self.len = l
+
+    def new_tmp_file(self):
+        f = TemporaryFile()
+        self.tmp_files.append(f)
+        return f
+
+    def get_curr_file_num(self):
+        if len(self.tmp_files) > 0:
+            return self.tmp_files[-1]
+        else:
+            return self.new_tmp_file()
+
+    def store(self, data):
+        f = self.get_curr_file_num()
+        pos = f.tell()
+
+        chunk = Chunk(self.len, f, pos)
+
+        data.sort()
+
+        for item in data:
+            f.write(item)
+            chunk.count += 1
+            pos += self.len
+            if pos >= self.max_file_size:
+                self.chunks.append(chunk)
+                f = self.new_tmp_file()
+                pos = 0
+                chunk = Chunk(self.len, f, pos)
+
+        if pos > 0:
+            self.chunks.append(chunk)
+
+    def store_last(self, data):
+        data.sort()
+        self.chunks.append(data)
+
+    def __iter__(self):
+        '''Use the heapq merge function to get an iterator that merges
+        all the chunks together'''
+        return merge(*self.chunks)
+    
 def print_usage():
     print '''
 %s: Index DB for MFEprimer-2.0
@@ -34,6 +115,7 @@ def optget():
     parser.add_option("-f", "--file", dest = "filename", help = "DNA file in fasta to be indexed")
     parser.add_option("-k", "--k", dest = "k", type='int', help = "K mer , default is 9", default = 9)
     parser.add_option("-o", "--out", dest = "out", help = "Index db file name")
+    parser.add_option("-c", "--chunk", dest = "chunk", help = "Number of kmers to sort in memory", default=1000000)
 
     (options, args) = parser.parse_args()
 
@@ -43,6 +125,9 @@ def optget():
 
     if not options.out:
         options.out = options.filename + '.sqlite3.db'
+
+    if options.chunk < 10000:
+        options.chunk = 10000
 
     return options
 
@@ -88,36 +173,6 @@ def parse_fasta_format(fh):
         if not line: return
 
     assert False, 'Should not reach this line'
-
-def get_free_memory_percent():
-    if platform.system() == 'Darwin':
-        # Get process info
-        vm = subprocess.Popen(['vm_stat'], stdout=subprocess.PIPE).communicate()[0]
-        installed_memory = float(subprocess.Popen(['sysctl', '-n', 'hw.memsize'], stdout=subprocess.PIPE).communicate()[0])
-
-        # Process vm_stat
-        vmLines = vm.split('\n')
-        sep = re.compile(':[\s]+')
-        vmStats = {}
-        for row in range(1,len(vmLines)-2):
-            rowText = vmLines[row].strip()
-            rowElements = sep.split(rowText)
-            vmStats[(rowElements[0])] = int(rowElements[1].strip('\.')) * 4096
-
-        total_comsumed = vmStats["Pages wired down"] + vmStats["Pages active"] + vmStats["Pages inactive"]
-
-        return (installed_memory - total_comsumed) / installed_memory * 100
-
-    elif platform.system() == 'Linux':
-        items = subprocess.Popen(['free', '-m'], stdout=subprocess.PIPE).communicate()[0].splitlines()[1].strip().split()
-        free = float(items[3]) + float(items[5]) + float(items[6])
-        total = float(items[1])
-
-        return free / total * 100
-    else:
-        print "Sorry, currently only support Mac OS and Linux."
-        return 0
-
 
 def insert_db(conn, mer_count, plus, minus):
     for mer_id in xrange(mer_count):
@@ -179,7 +234,18 @@ def DNA2int(seq):
 
     return plus_mer
 
-def index(filename, k, dbname):
+def store_to_db(conn, mer_id, next_mer_id, collation, record_names):
+    if mer_id >= 0:
+        plus = ";".join('%s:%s' % (record_names[x[0]], ",".join(str(y) for y in x[1])) for x in collation['+'])
+        minus = ";".join('%s:%s' % (record_names[x[0]], ",".join(str(y) for y in x[1])) for x in collation['-'])
+        conn.execute("insert into pos (mer_id, plus, minus)"
+                     "values (?, ?, ?)", (mer_id, plus, minus))
+
+    conn.executemany("insert into pos (mer_id, plus, minus)"
+                     "values (?, ?, ?)",
+                     ((x, '', '') for x in range(mer_id + 1, next_mer_id)))
+
+def index(filename, k, dbname, max_count):
     ''''''
     start = time()
 
@@ -195,27 +261,34 @@ def index(filename, k, dbname):
     minus text
     );''')
 
-    plus = ['']*mer_count
-    minus = ['']*mer_count
 
-    is_empty = False
-    is_db_new = True
+    count = 0
+    record_num = 0
+    record_names = []
 
+    # Format for packing data.  By using big-endian byte ordering,
+    # we get the result that a simple sort will put everything in the order
+    # we want.
+    if k > 16:
+        fmt = '>QII'
+    else:
+        fmt = '>III'
+
+    fmt_len = calcsize(fmt)
+    sorter = MergeSorter(fmt_len)
+
+    # Accumulator for packed data items
+    items = []
+
+    # Get data and sort
     for record_id, record_desc, fasta_seq in parse_fasta_format(open(filename)):
         is_empty = False
         print record_id
-
-        #print 'Time used: ', time() - start
-
-        #plus_mer_list = [''] * mer_count
-        #minus_mer_list = [''] * mer_count
-        plus_mer_list = {}
-        minus_mer_list = {}
+        record_names.append(record_id)
+        record_num = len(record_names) - 1
 
         for i in xrange(len(fasta_seq)-k + 1):
-            #start = time()
             kmer = fasta_seq[i:(i+k)]
-            #print kmer, i
 
             try:
                 plus_mer_id, minus_mer_id = DNA2int_2(kmer)
@@ -223,53 +296,42 @@ def index(filename, k, dbname):
                 # Skip the unrecognized base, such as 'N'
                 continue
 
-            if plus_mer_list.has_key(plus_mer_id):
-                plus_mer_list[plus_mer_id] += ',%i' % (i+k-1)
-            else:
-                plus_mer_list[plus_mer_id] = str(i+k-1)
+            items.append(pack(fmt, plus_mer_id, record_num, i + k - 1))
+            items.append(pack(fmt, minus_mer_id, record_num | 0x80000000, i))
+            count += 2
 
-            if minus_mer_list.has_key(minus_mer_id):
-                minus_mer_list[minus_mer_id] += ',%i' % (i)
-            else:
-                minus_mer_list[minus_mer_id] = str(i)
+            if count >= max_count:
+                sorter.store(items)
+                items = []
+                count = 0
+                
+    # Don't forget the last bit
+    sorter.store_last(items)
 
-
-        #print 'Index time used: ', time() - start
-        #start = time()
-        for mer_id, pos in plus_mer_list.items():
-            if plus[mer_id]:
-                plus[mer_id] += ';%s:%s' % (record_id, pos)
-            else:
-                plus[mer_id] = '%s:%s' % (record_id, pos)
-
-        for mer_id, pos in minus_mer_list.items():
-            if minus[mer_id]:
-                minus[mer_id] += ';%s:%s' % (record_id, pos)
-            else:
-                minus[mer_id] = '%s:%s' % (record_id, pos)
-
-        #print 'Merge time used: ', time() - start
-
-        memory_percent = get_free_memory_percent()
-        if memory_percent < 30:
-            if is_db_new:
-                insert_db(conn, mer_count, plus, minus)
-                is_db_new = False
-            else:
-                update_db(conn, mer_count, plus, minus)
-
-            # Empty the container
-            plus = ['']*mer_count
-            minus = ['']*mer_count
-            is_empty = True
-
-            print 'Empty plus and minus due to the memory problem.'
-
-    if not is_empty:
-        if is_db_new:
-            insert_db(conn, mer_count, plus, minus)
+    # Merge it all together
+    last_kmer = -1
+    last_collation = { '+' : [], '-' : [] }
+    
+    for item in sorter:
+        mer_id, record_num, pos = unpack(fmt, item)
+        if record_num < 0x80000000:
+            dirn = '+'
         else:
-            update_db(conn, mer_count, plus, minus)
+            record_num &= 0x7fffffff
+            dirn = '-'
+        
+        if mer_id != last_kmer:
+            store_to_db(conn, last_kmer, mer_id, last_collation, record_names)
+            last_kmer = mer_id
+            last_collation = { '+' : [], '-' : [] }
+
+        if (len(last_collation[dirn]) == 0
+            or last_collation[dirn][-1][0] != record_num):
+            last_collation[dirn].append((record_num, []))
+        last_collation[dirn][-1][1].append(pos)
+
+    store_to_db(conn, last_kmer, mer_count, last_collation, record_names)
+    conn.commit()
 
     print "Time used: %s" % str(datetime.timedelta(seconds=(time() - start)))
     print 'Done.'
@@ -277,7 +339,8 @@ def index(filename, k, dbname):
 def main():
     '''main'''
     options = optget()
-    index(options.filename, options.k, options.out)
+    index(options.filename, options.k, options.out, options.chunk)
 
 if __name__ == "__main__":
     main()
+

--- a/lib/qu/pymfeindex
+++ b/lib/qu/pymfeindex
@@ -1,4 +1,32 @@
 #!/usr/bin/env python
+
+# Copyright (c) 2013 Wubin Qu
+# Copyright (c) 2015 Genome Research Limited
+
+# Authors: Wubin Qu, Robert Davies
+
+# MIT License
+
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
 from __future__ import division
 
 import os
@@ -204,7 +232,7 @@ Usage:
     %s -f human.genomic -k 9 -o index_db_name
 
 Author: Wubin Qu <quwubin@gmail.com>
-Last updated: 2012-9-28
+Last updated: 2015-9-2
     ''' % (os.path.basename(sys.argv[0]), os.path.basename(sys.argv[0]))
 
 def optget():


### PR DESCRIPTION
This is a change to how pymfeindex works.  It has two goals: to improve the execution speed for big input files (e.g. the Human genome) and to make it easier to control the amount of memory the program uses.

The first of these is achieved mainly by using bytearrays (which grow in linear time) instead of python strings (which are quadratic).

For the second, the strategy of collecting data in a hash table is replaced with a method based on sorting and merging.  Partially sorted data can be written to disk and re-read later at the merge stage.  This makes it much easier to limit the memory used.

The result is a little bit slower when indexing small inputs, but much faster on big ones.  For example, I managed to index the human genome in about 10 hours, using about 6.6 Gb RAM, and about 20 Gb of temporary storage.
